### PR TITLE
 Make 'realpath' system independent

### DIFF
--- a/libexec/helmenv---version
+++ b/libexec/helmenv---version
@@ -12,7 +12,7 @@
 set -e
 [ -n "$HELMENV_DEBUG" ] && set -x
 
-version="0.1.0"
+version="0.1.1"
 git_revision=""
 
 if cd "${BASH_SOURCE%/*}" 2>/dev/null && git remote -v 2>/dev/null | grep -q helmenv; then

--- a/libexec/helmenv-versions
+++ b/libexec/helmenv-versions
@@ -6,6 +6,7 @@
 
 set -e
 [ -n "$HELMENV_DEBUG" ] && set -x
+source ${HELMENV_ROOT}/libexec/helpers.sh
 
 unset bare
 unset skip_aliases

--- a/libexec/helpers.sh
+++ b/libexec/helpers.sh
@@ -6,3 +6,16 @@ function error_and_die() {
 function info() {
   echo -e "\033[0;32m[INFO] ${1}\033[0;39m"
 }
+
+function realpath() {
+  OURPWD=$PWD
+  cd "$(dirname "$1")"
+  LINK=$(readlink "$(basename "$1")")
+  while [ "$LINK" ]; do
+    cd "$(dirname "$LINK")"
+    LINK=$(readlink "$(basename "$1")")
+  done
+  REALPATH="$PWD/$(basename "$1")"
+  cd "$OURPWD"
+  echo "$REALPATH"
+}


### PR DESCRIPTION
## Description
Added a system independent `realpath` helper function.

## Issue
```bash
helmenv versions
```
throws
```bash
~/.helmenv/libexec/helmenv-versions: line 31: realpath: command not found
```

## System
MacOS 10.14.2
iTerm2 Build 3.2.7
zsh 5.3 (x86_64-apple-darwin18.0)

## Steps to reproduce

1. Install a new version of helm
```bash
helmenv install <version>
```
2.
```bash
helmenv versions
```

